### PR TITLE
Only load yaml files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,11 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# VIM swap files
+[._]*.s[a-v][a-z]
+# !*.svg  # uncomment if you need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-When contributing to this repository, we encourage to first discuss the change you wish to make via issue before submiting a change. We're not strict about this and for small changes feel free to PR direcltely.
+When contributing to this repository, we encourage to first discuss the change you wish to make via issue before submiting a change. We're not strict about this and for small changes feel free to PR directly.
 
 ## Development Environment
 

--- a/cmd/istio-config-validator/main.go
+++ b/cmd/istio-config-validator/main.go
@@ -65,11 +65,16 @@ func getFiles(names []string) []string {
 			if err != nil {
 				log.Fatal(err.Error())
 			}
-			if !info.IsDir() {
+			if !info.IsDir() && isYaml(info) {
 				files = append(files, path)
 			}
 			return nil
 		})
 	}
 	return files
+}
+
+func isYaml(info os.FileInfo) bool {
+	var extension = filepath.Ext(info.Name())
+	return extension == ".yaml" || extension == ".yml"
 }

--- a/cmd/istio-config-validator/main.go
+++ b/cmd/istio-config-validator/main.go
@@ -75,6 +75,6 @@ func getFiles(names []string) []string {
 }
 
 func isYaml(info os.FileInfo) bool {
-	var extension = filepath.Ext(info.Name())
+	extension := filepath.Ext(info.Name())
 	return extension == ".yaml" || extension == ".yml"
 }


### PR DESCRIPTION
This pull request is a small one, so I followed the instructions in `CONTRIBUTING.md` and just created it directly.

I currently use vim to edit the routes yaml files, and the binary swap files it generates are included in the set of files to validate. That would, of course, fail: a binary file is no yaml. This PR makes it so only files with a `.yaml` or `.yml` extension (case-sensitive) are parsed and ran.

I also added the swap files to .gitignore, and fixed a typo in the contribution guidelines.