### PR TITLE
Test against go 1.16 and go 1.15

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x]
+        go-version: [1.15.x, 1.16.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -52,5 +52,6 @@ jobs:
       run: |
         export PATH=$PATH:$(go env GOPATH)/bin
         go get -u github.com/schrej/godacov
+        go mod tidy
         go test -coverprofile=./coverage.out ./...
         godacov -r ./coverage.out -t ${{ secrets.CODACY_PROJECT_TOKEN }} -c ${{ github.sha }}

--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,5 @@ run:
 	docker run -it --rm --name istio_config_validator \
 				-v ${CURRENTPATH}:${WORKDIR} \
 				-w ${WORKDIR} \
-				golang:1.13 \
+				golang:1.16 \
 				go run cmd/istio-config-validator/main.go -t examples/ examples/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getyourguide/istio-config-validator
 
-go 1.13
+go 1.15
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
Added an additional `go mod tidy` to the testing workflow.
Once we deprecate go 1.15 in testing, we can remove it again and switch all the `go get -u ...` to `go install ...@latest`