### PR TITLE
NoTicket: Use self-hosted runners instead of GitHub-hosted runners

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, small]
     steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.github/workflows/renovate-auto-approve.yml
+++ b/.github/workflows/renovate-auto-approve.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   auto-approve:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, small]
     if: ${{ github.actor == 'renovate[bot]' || github.actor == 'dependabot[bot]' }}
     steps:
       - name: Approve Renovate PR


### PR DESCRIPTION
This pull request is to change the CI runner from GitHub-hosted runners (ubuntu-latest) to self-hosted runners. This change is necessary to improve the cost and control over our build environment. Please review our changes and provide your feedback.
