### PR TITLE
Remove redundant logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0
-	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20240707233637-46b078467d37
 	gopkg.in/yaml.v3 v3.0.1
 	istio.io/api v1.23.0-alpha.0
@@ -121,6 +120,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.25.0 // indirect
 	golang.org/x/mod v0.19.0 // indirect
 	golang.org/x/net v0.27.0 // indirect

--- a/internal/pkg/parser/testcase.go
+++ b/internal/pkg/parser/testcase.go
@@ -10,8 +10,6 @@ import (
 	"os"
 	"strings"
 
-	"go.uber.org/zap/zapcore"
-	"golang.org/x/exp/slog"
 	yamlV3 "gopkg.in/yaml.v3"
 	networkingv1alpha3 "istio.io/api/networking/v1alpha3"
 )
@@ -124,8 +122,6 @@ func ParseTestCases(files []string, strict bool) ([]*TestCase, error) {
 				if errors.Is(err, io.EOF) {
 					break
 				}
-
-				slog.Debug("error while trying to unmarshal into interface", zapcore.Field{Key: "file", Type: zapcore.StringType, String: file})
 				return out, fmt.Errorf("error while trying to unmarshal into interface (%s): %w", file, err)
 			}
 
@@ -140,9 +136,7 @@ func ParseTestCases(files []string, strict bool) ([]*TestCase, error) {
 
 			var yamlFile TestCaseYAML
 			if err := jsonDecoder.Decode(&yamlFile); err != nil {
-				slog.Debug("unmarshaling failed for file %q: %w", file, err)
 				return nil, fmt.Errorf("unmarshaling failed for file %q: %w", file, err)
-
 			}
 
 			out = append(out, yamlFile.TestCases...)


### PR DESCRIPTION
slog is called wrongly and the debug logs are redundant as we return an error.