### PR TITLE
Validate Routes in Test Cases throwing an error if route is not specified when required

### DIFF
--- a/internal/pkg/parser/testcase.go
+++ b/internal/pkg/parser/testcase.go
@@ -21,6 +21,8 @@ var (
 	ErrEmptyMethodList = errors.New("method list is empty")
 	// ErrEmptyURIList indicates an empty URI list
 	ErrEmptyURIList = errors.New("URI list is empty")
+	// ErrRouteRequiredWhenWantMatchFalse indicates missing route when wantMatch is false
+	ErrRouteRequiredWhenWantMatchFalse = errors.New("route must be provided")
 )
 
 // TestCaseYAML define the list of TestCase
@@ -139,7 +141,12 @@ func ParseTestCases(files []string, strict bool) ([]*TestCase, error) {
 				return nil, fmt.Errorf("unmarshaling failed for file %q: %w", file, err)
 			}
 
-			out = append(out, yamlFile.TestCases...)
+			for _, tc := range yamlFile.TestCases {
+				if tc.Route == nil || len(tc.Route) == 0 {
+					return nil, fmt.Errorf("validation failed for file %q test case %q: %w", file, tc.Description, ErrRouteRequiredWhenWantMatchFalse)
+				}
+				out = append(out, tc)
+			}
 		}
 	}
 	return out, nil

--- a/internal/pkg/parser/testcase.go
+++ b/internal/pkg/parser/testcase.go
@@ -21,8 +21,8 @@ var (
 	ErrEmptyMethodList = errors.New("method list is empty")
 	// ErrEmptyURIList indicates an empty URI list
 	ErrEmptyURIList = errors.New("URI list is empty")
-	// ErrRouteRequiredWhenWantMatchFalse indicates missing route when wantMatch is false
-	ErrRouteRequiredWhenWantMatchFalse = errors.New("route must be provided")
+	// ErrRouteRequiredForSimpleRouting indicates missing route when wantMatch is false
+	ErrRouteRequiredForSimpleRouting = errors.New("route must be provided when using simple routing")
 )
 
 // TestCaseYAML define the list of TestCase
@@ -142,8 +142,8 @@ func ParseTestCases(files []string, strict bool) ([]*TestCase, error) {
 			}
 
 			for _, tc := range yamlFile.TestCases {
-				if tc.Route == nil || len(tc.Route) == 0 {
-					return nil, fmt.Errorf("validation failed for file %q test case %q: %w", file, tc.Description, ErrRouteRequiredWhenWantMatchFalse)
+				if tc.Rewrite == nil && tc.Redirect == nil && tc.Delegate == nil && len(tc.Route) == 0 {
+					return nil, fmt.Errorf("validation failed for file %q test case %q: %w", file, tc.Description, ErrRouteRequiredForSimpleRouting)
 				}
 				out = append(out, tc)
 			}

--- a/internal/pkg/parser/testcase_test.go
+++ b/internal/pkg/parser/testcase_test.go
@@ -16,6 +16,12 @@ func TestUnknownField(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestParseTestCasesRequiresRouteWhenWantMatchIsFalse(t *testing.T) {
+	testsFiles := []string{"testdata/missing_route.yml"}
+	_, err := ParseTestCases(testsFiles, false)
+	require.ErrorIs(t, err, ErrRouteRequiredWhenWantMatchFalse)
+}
+
 func TestParseTestCases(t *testing.T) {
 	expectedTestCases := []*TestCase{
 		{Description: "happy path users"},

--- a/internal/pkg/parser/testcase_test.go
+++ b/internal/pkg/parser/testcase_test.go
@@ -19,7 +19,7 @@ func TestUnknownField(t *testing.T) {
 func TestParseTestCasesRequiresRouteWhenWantMatchIsFalse(t *testing.T) {
 	testsFiles := []string{"testdata/missing_route.yml"}
 	_, err := ParseTestCases(testsFiles, false)
-	require.ErrorIs(t, err, ErrRouteRequiredWhenWantMatchFalse)
+	require.ErrorIs(t, err, ErrRouteRequiredForSimpleRouting)
 }
 
 func TestParseTestCases(t *testing.T) {

--- a/internal/pkg/parser/testdata/missing_route.yml
+++ b/internal/pkg/parser/testdata/missing_route.yml
@@ -1,0 +1,14 @@
+testCases:
+  - description: wantMatch false requires route
+    wantMatch: false
+    request:
+      authority: ["example.com"]
+      method: ["GET"]
+      uri: ["/"]
+
+  - description: wantMatch true requires route
+    wantMatch: true
+    request:
+      authority: ["example.com"]
+      method: ["GET"]
+      uri: ["/"]


### PR DESCRIPTION
## Validate Routes in Test Cases


Discovered in https://github.com/getyourguide/routes/pull/3029 , see (https://github.com/getyourguide/routes/pull/3029#discussion_r2704499904)
---


This pull request introduces validation to ensure that when simple routing is requested (with wantMatch set to false), a route must be provided in the test cases. Without a defined route, the parser now returns an explicit error.

Changes include:
- Addition of an error constant `ErrRouteRequiredForSimpleRouting` to signal missing required routes.
- Parser update to check that test cases either define a rewrite, redirect, delegate, or at least one route when wantMatch is false.
- A new test file with test cases illustrating missing route scenarios.
- Unit tests validating that missing routes cause parsing to fail appropriately.

This improves the robustness of configuration validation by enforcing necessary route definitions in test cases.